### PR TITLE
Replace newsletter CTA in home page with featured portfolio projects

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,22 +2,39 @@
 title = "Home"
 template = "index.html"
 description = "I create beautiful, delightful solutions that contribute back to the human experience."
+[extra]
+
+[[extra.portfolio_items]]
+title = "Last One Flying"
+description = "I created a retro-inspired arcade space shooter game. Made with the Phaser Game Framework."
+thumbnail = "https://ik.imagekit.io/mune/last-one-flying-gameplay_x9m2-BeKo.gif?updatedAt=1758306529668"
+thumbnail_alt_text = "Last One Flying"
+path = "/portfolio/last-one-flying"
+
+[[extra.portfolio_items]]
+title = "Pomodoro Timer UWP"
+description = "A pomodoro timer app with features like \"always-on-top\" mode, background support and the ability to customise your each interval and how many sessions you'll have."
+thumbnail = "https://ik.imagekit.io/mune/pomodoro-timer_GDR4r4_faNPO.png"
+thumbnail_alt_text = "A program with a timer showing the current time left in minutes and seconds."
+path = "/portfolio/pomodoro-timer-uwp"
+badges=["<a href=\"https://www.producthunt.com/posts/pomodoro-timer-uwp?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-pomodoro-timer-uwp\" target=\"_blank\"><img src=\"https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=136007&theme=light\" alt=\"Pomodoro Timer UWP - Be more productive with your time | Product Hunt\" style=\"width: 250px; height: 54px;\" width=\"250\" height=\"54\"></a>"]
+
+
+[[extra.portfolio_items]]
+title = "Vala Website (2022)"
+description = "I created a website for a programming language called Vala. It replaces an old set of wiki pages with a fully branded original website"
+thumbnail = "https://ik.imagekit.io/mune/vala-www-capture_ahfD-0S9X.png"
+thumbnail_alt_text = "Vala Hero Image"
+path = "/portfolio/vala-website-2022"
+
 
 +++
 
 {{ home_h1() }}
 
-{{ newsletter_sign_up(title="Subscribe to my newsletter to <em>be the first</em> to know about upcoming projects")}}
+## Portfolio - Featured Projects
 
-
----
-
-## Featured Projects {.featured-projects}
-
-- [Last One Flying (Retro Arcade Space Shooter Game)](@/portfolio/last-one-flying.md)
-- [Vala Programming Language Website](@/portfolio/vala-website-2022.md)
-- [Four-In-A-Row HTML5 Canvas Game Tutorial](@/blog/making-four-in-a-row-part-1.md)
-
+{{ featured_portfolio_items() }}
 
 {% cta() %}
 [See what else I've made](@/portfolio/_index.md)

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
 {% block head %}
 {{ head_macros::og_data(title=section.title, description=section.description) }}
 <link rel="stylesheet" type="text/css" href="/css/home.css">
+<link rel="stylesheet" type="text/css" href="/css/portfolio.css">
 {% endblock %}
 
 {% block main_content %}

--- a/templates/shortcodes/featured_portfolio_items.html
+++ b/templates/shortcodes/featured_portfolio_items.html
@@ -1,0 +1,20 @@
+{% import "macros/image.html" as image_macros %}
+
+<ul class="portfolio">
+	{% for item in section.extra.portfolio_items %}
+	<li>
+		<a href="{{ get_url(path=item.path)}}">
+			{{ image_macros::portfolio_image(src=item.thumbnail, alt=item.thumbnail_alt_text) }}
+			{{ item.title }}
+		</a>
+		{{ item.description|safe }}
+		{% if item.badges %}
+			<div class="badges">
+				{% for badge in item.badges %}
+				{{ badge|safe }}
+				{% endfor %}
+			</div>
+		{% endif %}
+	</li>
+	{% endfor %}
+</ul>


### PR DESCRIPTION
This pull request introduces a new "Featured Portfolio Projects" section to the home page, making it easier to showcase selected projects visually and with richer metadata. The main changes include restructuring how portfolio items are stored and rendered, updating the home page layout, and adding supporting styles.

**Home page portfolio improvements:**

* Added a structured `extra.portfolio_items` array in `content/_index.md` to define featured projects with titles, descriptions, thumbnails, alt text, paths, and optional badges.
* Replaced the old markdown links and project section with a new `{{ featured_portfolio_items() }}` shortcode for dynamic rendering of portfolio items on the home page.

**Template and rendering updates:**

* Created a new `templates/shortcodes/featured_portfolio_items.html` template to render portfolio items as a styled list, including support for images and badges.
* Updated `templates/index.html` to include the new `portfolio.css` stylesheet for home/portfolio styling.

Fixes #41 